### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=This library is heavily commented, and includes support for alarms.
 category=Timing
 url=https://github.com/orbitalair/Rtc_Pcf8563
 architectures=avr
-includes=Rtc_Pcf8563
+includes=Rtc_Pcf8563.h
 depends=


### PR DESCRIPTION
The includes field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > LIBRARYNAME**. This field should specify the primary header file(s) of the library.

The previous `includes` value caused the following incorrect `#include` directive to be added to the sketch:
```c++
#include <Rtc_Pcf8563>
```

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format