### PR TITLE
Function SetTime parameter order mismatch

### DIFF
--- a/src/Rtc_Pcf8563.h
+++ b/src/Rtc_Pcf8563.h
@@ -116,7 +116,7 @@ class Rtc_Pcf8563 {
         void setDate(byte day, byte weekday, byte month, byte century, byte year);
         void getTime();    /* get time vars + 2 status bytes to local vars */
         void getAlarm();
-        void setTime(byte sec, byte minute, byte hour);
+        void setTime(byte hour, byte minute, byte sec);
         byte readStatus2();
         boolean alarmEnabled();
         boolean alarmActive();


### PR DESCRIPTION
Swaped order of Hour and second to match definition of SetTime on cpp file 