### PR TITLE
Change Rtc_Pcf8563::version return type to const char*

### DIFF
--- a/src/Rtc_Pcf8563.cpp
+++ b/src/Rtc_Pcf8563.cpp
@@ -376,7 +376,7 @@ void Rtc_Pcf8563::getTime()
     hour = bcdToDec(Wire.receive() & 0x3f);
 }
 
-char *Rtc_Pcf8563::version(){
+const char *Rtc_Pcf8563::version(){
   return RTCC_VERSION;  
 }
 

--- a/src/Rtc_Pcf8563.cpp
+++ b/src/Rtc_Pcf8563.cpp
@@ -353,13 +353,39 @@ void Rtc_Pcf8563::clearAlarm()
     Wire.send(status2);
     Wire.endTransmission();
 }
-
 /**
- * @brief Load time and date
- * @return pcfTime -> struct containing time and date
+ * @brief call this first to load current date values to variables
  *
  */
-pcfTime Rtc_Pcf8563::getTimeDate()
+void Rtc_Pcf8563::getDate()
+{
+    /* set the start byte of the date data */
+    Wire.beginTransmission(Rtcc_Addr);
+    Wire.send(RTCC_DAY_ADDR);
+    Wire.endTransmission();
+
+    Wire.requestFrom(Rtcc_Addr, 4); // request 4 bytes
+    // 0x3f = 0b00111111
+    day = bcdToDec(Wire.receive() & 0x3f);
+    // 0x07 = 0b00000111
+    weekday = bcdToDec(Wire.receive() & 0x07);
+    // get raw month data byte and set month and century with it.
+    month = Wire.receive();
+    if (month & RTCC_CENTURY_MASK) {
+        century = 1;
+    } else {
+        century = 0;
+    }
+    // 0x1f = 0b00011111
+    month = month & 0x1f;
+    month = bcdToDec(month);
+    year = bcdToDec(Wire.receive());
+}
+/**
+ * @brief call this first to load current time values to variables
+ *
+ */
+void Rtc_Pcf8563::getTime()
 {
     /* set the start byte , get the 2 status bytes */
     Wire.beginTransmission(Rtcc_Addr);
@@ -370,33 +396,10 @@ pcfTime Rtc_Pcf8563::getTimeDate()
     status1 = Wire.receive();
     status2 = Wire.receive();
     // 0x7f = 0b01111111
-    time.Second = bcdToDec(Wire.receive() & 0x7f);
-    time.Minute = bcdToDec(Wire.receive() & 0x7f);
+    sec = bcdToDec(Wire.receive() & 0x7f);
+    minute = bcdToDec(Wire.receive() & 0x7f);
     // 0x3f = 0b00111111
-    time.Hour = bcdToDec(Wire.receive() & 0x3f);
-
-    Wire.beginTransmission(Rtcc_Addr);
-    Wire.send(RTCC_DAY_ADDR);
-    Wire.endTransmission();
-
-    Wire.requestFrom(Rtcc_Addr, 4); // request 4 bytes
-    // 0x3f = 0b00111111
-    time.Day = bcdToDec(Wire.receive() & 0x3f);
-    // 0x07 = 0b00000111
-    time.Weekday = bcdToDec(Wire.receive() & 0x07);
-    // get raw month data byte and set month and century with it.
-    time.Month = Wire.receive();
-    if (month & RTCC_CENTURY_MASK) {
-        century = 1;
-    } else {
-        century = 0;
-    }
-    // 0x1f = 0b00011111
-    time.Month = month & 0x1f;
-    time.Month = bcdToDec(month);
-    time.Year = bcdToDec(Wire.receive());
-
-    return time;
+    hour = bcdToDec(Wire.receive() & 0x3f);
 }
 
 /**
@@ -519,6 +522,37 @@ char* Rtc_Pcf8563::formatDate(byte style)
 }
 
 /**
+ * @brief get seconds, needs getTime() to be called before
+ *
+ * @return byte -> seconds from 0 to 59
+ */
+byte Rtc_Pcf8563::getSecond()
+{
+    return sec;
+}
+
+/**
+ * @brief get minutes, needs getTime() to be called before
+ *
+ * @return byte -> minutes from 0 to 59
+ */
+byte Rtc_Pcf8563::getMinute()
+{
+    return minute;
+}
+
+/**
+ * @brief get hour, needs getTime() to be called before
+ *
+ * @return byte -> hours from 0 to 23
+ */
+byte Rtc_Pcf8563::getHour()
+{
+    getTime();
+    return hour;
+}
+
+/**
  * @brief get alarm minute, needs getAlarm() to be called before
  *
  * @return byte -> minute from 0 to 59
@@ -559,7 +593,47 @@ byte Rtc_Pcf8563::getAlarmWeekday()
 }
 
 /**
- * @brief Staus register1, set during getTimeDate() operation
+ * @brief get day, needs getDate() to be called before
+ *
+ * @return byte -> day from 1 to 31
+ */
+byte Rtc_Pcf8563::getDay()
+{
+    return day;
+}
+
+/**
+ * @brief get month, needs getDate() to be called before
+ *
+ * @return byte -> month from 1 to 12
+ */
+byte Rtc_Pcf8563::getMonth()
+{
+    return month;
+}
+
+/**
+ * @brief get year, needs getDate() to be called before.
+ *
+ * @return byte -> day from 0 to 99
+ */
+byte Rtc_Pcf8563::getYear()
+{
+    return year;
+}
+
+/**
+ * @brief get weekday, needs getDate() to be called before
+ *
+ * @return byte -> day from 0 to 6
+ */
+byte Rtc_Pcf8563::getWeekday()
+{
+    return weekday;
+}
+
+/**
+ * @brief Staus register1, set during getTime() operation
  *
  * @return byte -> Staus register1
  */
@@ -569,7 +643,7 @@ byte Rtc_Pcf8563::getStatus1()
 }
 
 /**
- * @brief Staus register2, set durung getTimeDate(), enableAlarm(), resetAlarm() and clearAlarm() operation
+ * @brief Staus register2, set durung getTime(), enableAlarm(), resetAlarm() and clearAlarm() operation
  *
  * @return byte -> Staus register2
  */

--- a/src/Rtc_Pcf8563.h
+++ b/src/Rtc_Pcf8563.h
@@ -148,7 +148,7 @@ class Rtc_Pcf8563 {
         /* date supports 3 styles as listed in the wikipedia page about world date/time. */
         char *formatDate(byte style=RTCC_DATE_US);
 
-        char *version();
+        const char *version();
         
     private:
         /* methods */

--- a/src/Rtc_Pcf8563.h
+++ b/src/Rtc_Pcf8563.h
@@ -102,16 +102,6 @@
 #define SQW_32HZ B10000010
 #define SQW_1HZ B10000011
 
-typedef struct {
-    byte Second;
-    byte Minute;
-    byte Hour;
-    byte Weekday;
-    byte Day;
-    byte Month;
-    byte Year;
-} pcfTime;
-
 /* arduino class */
 class Rtc_Pcf8563 {
 public:
@@ -120,8 +110,9 @@ public:
     void initClock(); /* zero out all values, disable all alarms */
     void clearStatus(); /* set both status bytes to zero */
 
-    pcfTime getTimeDate(); /* get date vals to local vars */
+    void getDate(); /* get date vals to local vars */
     void setDate(byte day, byte weekday, byte month, byte century, byte year);
+    void getTime(); /* get time vars + 2 status bytes to local vars */
     void getAlarm();
     void setTime(byte sec, byte minute, byte hour);
     byte readStatus2();
@@ -135,6 +126,13 @@ public:
     void setSquareWave(byte frequency);
     void clearSquareWave();
 
+    byte getSecond();
+    byte getMinute();
+    byte getHour();
+    byte getDay();
+    byte getMonth();
+    byte getYear();
+    byte getWeekday();
     byte getStatus1();
     byte getStatus2();
 
@@ -154,8 +152,14 @@ private:
     /* methods */
     byte decToBcd(byte value);
     byte bcdToDec(byte value);
-    /* time variable */
-    pcfTime time;
+    /* time variables */
+    byte hour;
+    byte minute;
+    byte sec;
+    byte day;
+    byte weekday;
+    byte month;
+    byte year;
     /* alarm */
     byte alarm_hour;
     byte alarm_minute;


### PR DESCRIPTION
Fixed incorrect return type of version method.
String constant shall not be cast to mutable char pointer.